### PR TITLE
Compilation issues on vm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian
 
 RUN apt-get -qy update && apt-get -qy install build-essential \
-    libqt4-dev libqscintilla2-dev pkg-config libboost-system-dev \
+    libqt4-dev libqtwebkit-dev libqscintilla2-dev pkg-config libboost-system-dev \
     libboost-filesystem-dev libboost-iostreams-dev
 
 RUN mkdir /build

--- a/sugarfoot/vm.cpp
+++ b/sugarfoot/vm.cpp
@@ -214,7 +214,7 @@ std::string get_compile_fun_json(const char* text, int line, std::list<std::stri
   ptree env;
 
   for (std::list<std::string>::iterator it = vars.begin(); it != vars.end(); it++) {
-    env.push_back(std::make_pair("", *it));
+    env.push_back(std::make_pair("", ptree(*it)));
   }
 
   pt.put ("text", text);


### PR DESCRIPTION
Not sure if the fix is correct or if the problem is generated because I have a different version of boost here:

I'm getting this error without wrapping the value passed for `std::make_pair` with `ptree`:

```
vm.cpp: In function 'std::__cxx11::string get_compile_fun_json(const char*, int, std::__cxx11::list<std::__cxx11::basic_string<char> >)':
vm.cpp:217:42: error: no matching function for call to 'boost::property_tree::basic_ptree<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> >::push_back(std::pair
<const char*, std::__cxx11::basic_string<char> >)'                                                                                                                                
     env.push_back(std::make_pair("", *it));
                                          ^
In file included from /usr/include/boost/property_tree/ptree.hpp:516:0,
                 from vm.cpp:205:
/usr/include/boost/property_tree/detail/ptree_implementation.hpp:362:9: note: candidate: boost::property_tree::basic_ptree<Key, Data, KeyCompare>::iterator boost::property_tree::b
asic_ptree<Key, Data, KeyCompare>::push_back(const value_type&) [with Key = std::__cxx11::basic_string<char>; Data = std::__cxx11::basic_string<char>; KeyCompare = std::less<std::
__cxx11::basic_string<char> >; boost::property_tree::basic_ptree<Key, Data, KeyCompare>::value_type = std::pair<const std::__cxx11::basic_string<char>, boost::property_tree::basic
_ptree<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >]                                                                                                    
         basic_ptree<K, D, C>::push_back(const value_type &value)
         ^~~~~~~~~~~~~~~~~~~~
/usr/include/boost/property_tree/detail/ptree_implementation.hpp:362:9: note:   no known conversion for argument 1 from 'std::pair<const char*, std::__cxx11::basic_string<char> >'
 to 'const value_type& {aka const std::pair<const std::__cxx11::basic_string<char>, boost::property_tree::basic_ptree<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<
char> > >&}'                                                                                                                                                                      
Makefile:53: recipe for target 'vm.o' failed
make: *** [vm.o] Error 1
```