### PR TITLE
std::stringstream's << can't take std::endl's

### DIFF
--- a/sugarfoot/process.cpp
+++ b/sugarfoot/process.cpp
@@ -538,7 +538,7 @@ oop Process::super_send(oop recv, oop selector, oop args, int* exc) {
   if (!fun) {
     std::stringstream s;
     s << _mmobj->mm_symbol_cstr(this, selector, true) << " not found in object " << recv;
-    DBG(s << endl);
+    DBG(s.str() << endl);
     *exc = 1;
     oop ex = mm_exception("DoesNotUnderstand", s.str().c_str());
     WARNING() << "raising DoesNotUnderstand: " << s.str() << endl;
@@ -550,7 +550,7 @@ oop Process::super_send(oop recv, oop selector, oop args, int* exc) {
   if (num_args != arity) {
     std::stringstream s;
     s << _mmobj->mm_symbol_cstr(this, selector, true) << ": expects " <<  arity << " but got " << num_args;
-    DBG(s << endl);
+    DBG(s.str() << endl);
     *exc = 1;
     WARNING() << "wrong arity: " << s.str() << endl;
     oop ex = mm_exception("ArityError", s.str().c_str());
@@ -574,7 +574,7 @@ oop Process::do_send(oop recv, oop selector, int num_args, int *exc) {
   if (!fun) {
     std::stringstream s;
     s << _mmobj->mm_symbol_cstr(this, selector, true) << " not found in object " << recv;
-    DBG(s << endl);
+    DBG(s.str() << endl);
     *exc = 1;
     oop ex = mm_exception("DoesNotUnderstand", s.str().c_str());
     WARNING() << "raising DoesNotUnderstand: " << s.str() << endl;
@@ -586,7 +586,7 @@ oop Process::do_send(oop recv, oop selector, int num_args, int *exc) {
   if (num_args != arity) {
     std::stringstream s;
     s << _mmobj->mm_symbol_cstr(this, selector, true) << ": expects " <<  arity << " but got " << num_args;
-    DBG(s << endl);
+    DBG(s.str() << endl);
     *exc = 1;
     WARNING() << "wrong arity: " << s.str() << endl;
     oop ex = mm_exception("ArityError", s.str().c_str());
@@ -659,7 +659,7 @@ oop Process::call(oop fun, oop args, int* exc) {
   if (num_args != arity) {
     std::stringstream s;
     s << _mmobj->mm_string_cstr(this, _mmobj->mm_function_get_name(this, fun)) << ": expects " <<  arity << " but got " << num_args;
-    DBG(s << endl);
+    DBG(s.str() << endl);
     oop ex = mm_exception("ArityError", s.str().c_str());
     WARNING() << "returning ArityError exception object " << ex << endl;
     *exc = 1;
@@ -682,7 +682,7 @@ oop Process::call_1(oop fun, oop arg, int* exc) {
   if (num_args != arity) {
     std::stringstream s;
     s << _mmobj->mm_string_cstr(this, _mmobj->mm_function_get_name(this, fun)) << ": expects " <<  arity << " but got " << num_args;
-    DBG(s << endl);
+    DBG(s.str() << endl);
     oop ex = mm_exception("ArityError", s.str().c_str());
     WARNING() << "returning ArityError exception object " << ex << endl;
     *exc = 1;
@@ -703,7 +703,7 @@ oop Process::call_2(oop fun, oop arg0, oop arg1, int* exc) {
   if (num_args != arity) {
     std::stringstream s;
     s << _mmobj->mm_string_cstr(this, _mmobj->mm_function_get_name(this, fun)) << ": expects " <<  arity << " but got " << num_args;
-    DBG(s << endl);
+    DBG(s.str() << endl);
     oop ex = mm_exception("ArityError", s.str().c_str());
     WARNING() << "returning ArityError exception object " << ex << endl;
     *exc = 1;
@@ -1071,7 +1071,7 @@ void Process::handle_super_send(number num_args) {
   if (num_args != arity) {
     std::stringstream s;
     s << _mmobj->mm_string_cstr(this, _mmobj->mm_function_get_name(this, fun)) << ": expects " <<  arity << " but got " << num_args;
-    DBG(s << endl);
+    DBG(s.str() << endl);
     oop ex = mm_exception("ArityError", s.str().c_str());
     WARNING() << "will raise ArityError: " << s.str() << endl;
     maybe_debug_on_raise(ex);
@@ -1118,7 +1118,7 @@ void Process::handle_send(number num_args) {
   if (!vararg && num_args != arity) {
     std::stringstream s;
     s << _mmobj->mm_string_cstr(this, _mmobj->mm_function_get_name(this, fun)) << ": expects " <<  arity << " but got " << num_args;
-    DBG(s << endl);
+    DBG(s.str() << endl);
     oop ex = mm_exception("ArityError", s.str().c_str());
     WARNING() << "will raise ArityError: " << s.str() << endl;
     maybe_debug_on_raise(ex);
@@ -1146,7 +1146,7 @@ void Process::handle_super_ctor_send(number num_args) {
     DBG("super Lookup failed");
     std::stringstream s;
     s << _mmobj->mm_symbol_cstr(this, selector) << " not found in child object " << instance;
-    DBG(s << endl);
+    DBG(s.str() << endl);
     //we rely on compiler generating a pop instruction to bind ex_oop to the catch var
     oop oo_ex = mm_exception("DoesNotUnderstand", s.str().c_str());
     WARNING() << "will raise DoesNotUnderstand: " << s.str() << endl;
@@ -1165,7 +1165,7 @@ void Process::handle_super_ctor_send(number num_args) {
   if (num_args != arity) {
     std::stringstream s;
     s << "arity and num_args differ: " << num_args << " != " << arity;
-    DBG(s << endl);
+    DBG(s.str() << endl);
     oop oo_ex = mm_exception("ArityError", s.str().c_str());
     WARNING() << "will raise ArityError: " << s.str() << endl;
     maybe_debug_on_raise(oo_ex);
@@ -1188,7 +1188,7 @@ void Process::handle_call(number num_args) {
   if (num_args != arity) {
     std::stringstream s;
     s << _mmobj->mm_string_cstr(this, _mmobj->mm_function_get_name(this, fun)) << ": expects " <<  arity << " but got " << num_args;
-    DBG(s << endl);
+    DBG(s.str() << endl);
     oop oo_ex = mm_exception("ArityError", s.str().c_str());
     WARNING() << "will raise ArityError: " << s.str() << endl;
     maybe_debug_on_raise(oo_ex);


### PR DESCRIPTION
This bug only shows up if the variable that prevents debugging isn't passed. Which means that you need to run `make debug` to see the issue. (run a `make clean` first).

Here's what I'm getting without the patch:

```
g++ -Wall -DQT_SHARED -I/usr/include/qt4 -I/usr/include/qt4/QtScript -I/usr/include/qt4/QtWebKit -I/usr/include/qt4 -I/usr/include/qt4/QtGui -I/usr/include/qt4 -I/usr/include/qt4/
QtNetwork -I/usr/include/qt4 -I/usr/include/qt4/QtCore -I/usr/include/qt4/Qsci/ -g -c -o process.o process.cpp                                                                    
In file included from process.hpp:10:0,
                 from process.cpp:5:
log.hpp: In instantiation of 'MMLog& MMLog::operator<<(const T&) [with T = std::__cxx11::basic_stringstream<char>]':
process.cpp:541:5:   required from here
log.hpp:78:17: error: no match for 'operator<<' (operand types are 'std::ostream {aka std::basic_ostream<char>}' and 'const std::__cxx11::basic_stringstream<char>')
       std::cerr << msg;
       ~~~~~~~~~~^~~~~~
log.hpp:78:17: note: candidate: operator<<(int, int) <built-in>
log.hpp:78:17: note:   no known conversion for argument 2 from 'const std::__cxx11::basic_stringstream<char>' to 'int'
In file included from /usr/include/c++/6/istream:39:0,
                 from /usr/include/c++/6/fstream:38,
                 from process.hpp:7,
                 from process.cpp:5:
/usr/include/c++/6/ostream:108:7: note: candidate: std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(std::basic_ostream<_CharT, 
_Traits>::__ostream_type& (*)(std::basic_ostream<_CharT, _Traits>::__ostream_type&)) [with _CharT = char; _Traits = std::char_traits<char>; std::basic_ostream<_CharT, _Traits>::__
ostream_type = std::basic_ostream<char>]                                                                                                                                          
       operator<<(__ostream_type& (*__pf)(__ostream_type&))
       ^~~~~~~~
/usr/include/c++/6/ostream:108:7: note:   no known conversion for argument 1 from 'const std::__cxx11::basic_stringstream<char>' to 'std::basic_ostream<char>::__ostream_type& (*)(
std::basic_ostream<char>::__ostream_type&) {aka std::basic_ostream<char>& (*)(std::basic_ostream<char>&)}'                                                                        
/usr/include/c++/6/ostream:117:7: note: candidate: std::basic_ostream<_CharT, _Traits>::__ostream_type& std::basic_ostream<_CharT, _Traits>::operator<<(std::basic_ostream<_CharT, 
_Traits>::__ios_type& (*)(std::basic_ostream<_CharT, _Traits>::__ios_type&)) [with _CharT = char; _Traits = std::char_traits<char>; std::basic_ostream<_CharT, _Traits>::__ostream_
type = std::basic_ostream<char>; std::basic_ostream<_CharT, _Traits>::__ios_type = std::basic_ios<char>]                                                                          
       operator<<(__ios_type& (*__pf)(__ios_type&))
       ^~~~~~~~
(...)
```