### PR TITLE
Load primitives from .so files

### DIFF
--- a/central/stdlib/Makefile
+++ b/central/stdlib/Makefile
@@ -4,10 +4,20 @@ include $(shell git rev-parse --show-toplevel)/common.mk
 
 $(call GEN_MEC_RULE)
 
+CXXFLAGS = -Wall -fPIC $(QT_CXXFLAGS) -I$(VM_DIR)
+
+LIBS = $(QT_LIBS)
+
+PRIM_QT_CODE := qt_prims.cpp
+PRIM_QT_COBJ := qt_prims.o
+PRIM_QT_DYNL := qt_prims.so
+
+$(PRIM_QT_COBJ): $(PRIM_QT_CODE)
+$(PRIM_QT_DYNL): $(PRIM_QT_COBJ); g++ -shared $(PRIM_QT_COBJ) $(LIBS) -o $@
 
 CODE := io.me qt.me remote_repl.me memetest.me
 BYTECODE := $(patsubst %.me,%.mec,$(CODE))
 
-
-build: $(BYTECODE)
+%.o: %.cpp; g++ $(CXXFLAGS) -c -o $@ $^
+build: $(BYTECODE) $(PRIM_QT_DYNL)
 clean:; -rm -f $(BYTECODE)

--- a/central/stdlib/qt_prims.cpp
+++ b/central/stdlib/qt_prims.cpp
@@ -2,7 +2,6 @@
 #include "process.hpp"
 Q_DECLARE_METATYPE (Process*);
 
-#include "qt_prims.hpp"
 #include "vm.hpp"
 #include "log.hpp"
 #include "mmobj.hpp"
@@ -38,7 +37,6 @@ Q_DECLARE_METATYPE (Process*);
 #include <QPushButton>
 #include <QTcpServer>
 #include <QTcpSocket>
-#include "log.hpp"
 
 
 #define DBG() _log << _log.yellow + _log.bold + "[prim|" << __FUNCTION__ << "] " << _log.normal
@@ -1981,7 +1979,7 @@ static int prim_qt_maybe_construct_qapp(Process* proc) {
 //   return 0;
 // }
 
-void qt_init_primitives(VM* vm) {
+extern "C" void init_primitives(VM* vm) {
   vm->register_primitive("qt_qapplication_new", prim_qapplication_new);
   vm->register_primitive("qt_qapplication_exec", prim_qapplication_exec);
   vm->register_primitive("qt_qapplication_exit", prim_qapplication_exit);

--- a/common.mk
+++ b/common.mk
@@ -25,6 +25,15 @@ PY_PATH := $(ROOT_DIR)/py
 # Python command used to compile .me into .mec
 PY_COMPILER_CMD := python -m pycompiler.compiler
 
+# Flags for compilation
+
+## Qt:
+QT_INC_DIRS = /usr/include /usr/local/include
+QT_INC_QSCI ?= $(dir $(foreach i,$(QT_INC_DIRS),$(shell find -L $(i) -name qscicommandset.h)))
+QT_PKGLIBS = QtCore QtGui QtScript QtWebKit QtNetwork
+QT_CXXFLAGS = $(shell pkg-config --cflags $(QT_PKGLIBS)) -I$(QT_INC_QSCI)
+QT_LIBS = $(shell pkg-config --libs $(QT_PKGLIBS)) -lqscintilla2
+
 ## Macro GEN_MEC_RULE: Creates Make rule to compile .me files
 ##
 ##   This macro comes in handy for directories full of .me source

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,27 +2,19 @@ include $(shell git rev-parse --show-toplevel)/common.mk
 
 BIN = $(MEME)
 
-# General flags
-INC_DIRS = /usr/include /usr/local/include
+CPP_FILES = log.cpp mec_image.cpp core_image.cpp vm.cpp	\
+	utils.cpp mmobj.cpp process.cpp prims.cpp mec_fun.cpp qsc.cpp	\
+	ctrl.cpp main.cpp
 
-# QT Flags
-INC_QSCI ?= $(dir $(foreach i,$(INC_DIRS),$(shell find -L $(i) -name qscicommandset.h)))
-QT_PKGLIBS = QtCore QtGui QtScript QtWebKit QtNetwork
-QT_CXXFLAGS = $(shell pkg-config --cflags $(QT_PKGLIBS)) -I$(INC_QSCI)
-QT_LIBS = $(shell pkg-config --libs $(QT_PKGLIBS)) -lqscintilla2
-
-CXXFLAGS = -Wall $(QT_CXXFLAGS)
-LIBS = -lboost_system -lboost_iostreams -lboost_filesystem -lgc $(QT_LIBS)
-
-CPP_FILES = log.cpp mec_image.cpp core_image.cpp vm.cpp utils.cpp	\
-	mmobj.cpp main.cpp process.cpp prims.cpp mec_fun.cpp
-HPP_FILES = mec_image.hpp core_image.hpp vm.hpp log.hpp utils.hpp	\
-	defs.hpp mmobj.hpp process.hpp prims.hpp mec_fun.hpp
-
-CPP_FILES += qt_prims.cpp qsc.cpp ctrl.cpp
-HPP_FILES += qt_prims.hpp qsc.hpp ctrl.hpp
+HPP_FILES = log.hpp mec_image.hpp core_image.hpp vm.hpp	\
+	utils.hpp mmobj.hpp process.hpp prims.hpp mec_fun.hpp qsc.hpp	\
+	ctrl.hpp defs.hpp
 
 OBJS = $(CPP_FILES:%.cpp=%.o)
+
+CXXFLAGS = -Wall -fPIC $(QT_CXXFLAGS)
+
+LIBS = -lboost_system -lboost_iostreams -lboost_filesystem -lgc -ldl $(QT_LIBS)
 
 # Main targets
 all: release
@@ -41,4 +33,4 @@ qsc.moc.cpp: qsc.hpp; moc $< > $@
 
 # Output binary
 %.o: %.cpp; g++ $(CXXFLAGS) -c -o $@ $^
-$(BIN): qsc.moc.cpp $(OBJS); g++ $(OBJS) $(LIBS) -o $@
+$(BIN): qsc.moc.cpp $(OBJS); g++ $(OBJS) $(LIBS) -Wl,-export-dynamic -o $@

--- a/src/prims.cpp
+++ b/src/prims.cpp
@@ -5,7 +5,6 @@
 #include "utils.hpp"
 #include "mmobj.hpp"
 #include "mec_image.hpp"
-#include "qt_prims.hpp"
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -3001,6 +3000,4 @@ void init_primitives(VM* vm) {
   vm->register_primitive("exit", prim_exit);
   vm->register_primitive("basename", prim_basename);
   vm->register_primitive("bench", prim_bench);
-
-  qt_init_primitives(vm);
 }

--- a/src/qt_prims.hpp
+++ b/src/qt_prims.hpp
@@ -1,8 +1,0 @@
-#ifndef QT_PRIMS_HPP
-#define QT_PRIMS_HPP
-
-class VM;
-
-void qt_init_primitives(VM* vm);
-
-#endif

--- a/src/vm.hpp
+++ b/src/vm.hpp
@@ -91,6 +91,7 @@ private:
   // void dump_prime_info();
   // void dictionary_dump(oop dict);
   // void parse_repository_path();
+  void maybe_load_primitives_file(const std::string& file_path_without_extension);
   oop maybe_compile_local_source(Process* proc, std::string filepath);
   bool is_mec_file_older_then_source(std::string src_file_path);
   void maybe_load_config();


### PR DESCRIPTION
The current strategy is to look for a file called `<module>_prims.so`
right before reading the `<module>.mec` file.

How does it work:
 * Do a `stat()` on `<module>_prims.so`, bail if it doesn't exist
 * If `<module>_prims.so` exists, do a `dlopen()` on it
 * If `dlopen()` works on the shared library, call the
   `init_primitives()` within the `.so` file

Changes required to do that:
 * In order to not require a `libmeme.so` to link to each extension,
   the main binary had to be recompiled with `-Wl,-export-dynamic` so
   it exports all the symbols that the incomplete `<module>_prims.so`
   will need
 * The file qt_prims.cpp was moved from `src` to `central/stdlib`
   where the module `qt.me` resides

Problems with this approach:
 * Each module loaded executes a new call to `stat()`. Modules without
   primitives will happen way more than modules with primitives and
   they shouldn't pay that price.
 * Maybe the primitives system shouldn't call a function that takes a
   pointer to the VM, but rather just export an associative array with
   the functions associated to their names and then
   `maybe_load_primitives_file` could call the method that adds it to
   the VM.

This is going to help #152 move forward.